### PR TITLE
Use compat tests in conda build

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -60,10 +60,6 @@ build:
     - OSX_VERSION
 
 test:
-  imports:
-    - mantid.kernel
-    - mantid.geometry
-    - mantid.api
 
 about:
   home:

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+set +x
+
+python -c"import mantid.kernel"
+python -c"import mantid.geometry"
+python -c"import mantid.api"
+
+conda install -c scipp -c conda-forge scipp psutil pytest git --yes
+
+python -c"import mantid;print('Compat testing using mantid', mantid.__version__)"
+python -c"import scipp;print('Compat testing using scipp', scipp.__version__)"
+
+git clone https://github.com/scipp/scipp.git
+cd scipp
+git fetch --all --tags
+git checkout tags/0.0.5 
+python -m pytest python/tests/compat/test_mantid.py 

--- a/run_test.sh
+++ b/run_test.sh
@@ -15,5 +15,7 @@ python -c"import scipp;print('Compat testing using scipp', scipp.__version__)"
 git clone https://github.com/scipp/scipp.git
 cd scipp
 git fetch --all --tags
-git checkout tags/0.5.0 # This must be updated for future scipp releases 
+latest_tag=$(git tag --sort=-creatordate | head -1)
+echo using scipp tests from tag $latest_tag
+git checkout $latest_tag
 python -m pytest python/tests/compat/test_mantid.py 

--- a/run_test.sh
+++ b/run_test.sh
@@ -15,5 +15,5 @@ python -c"import scipp;print('Compat testing using scipp', scipp.__version__)"
 git clone https://github.com/scipp/scipp.git
 cd scipp
 git fetch --all --tags
-git checkout tags/0.0.5 
+git checkout tags/0.5.0 # This must be updated for future scipp releases 
 python -m pytest python/tests/compat/test_mantid.py 


### PR DESCRIPTION
Additional testing would prevent us putting new `mantid-framework` packages into our ecosystem if they were not compatible with scipp.

[See successful dry run results](https://dev.azure.com/scipp/mantid-framework-conda-recipe/_build/results?buildId=3020&view=results) Note that some tests were skipped to to insufficient virtual memory, but that should be dealt with separately I think.

Item of https://github.com/scipp/scipp/issues/1570