### PR TITLE
Export runtime requirements

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -10,17 +10,12 @@ requirements:
   build:
     - _openmp_mutex {{ _openmp_mutex }} [linux64]
     - blas
-    - boost {{ boost }}
     - cmake
     - eigen
-    - gsl
     - gxx_linux-64 8.* [linux64]
-    - h5py
     - hdf4
     - hdf5
     - jemalloc
-    - jsoncpp
-    - librdkafka
     - muparser
     - nexus
     - ninja
@@ -28,31 +23,32 @@ requirements:
     - openblas
     - openssl
     - pkg-config
-    - poco
-    - python {{ python }}
     - tbb-devel
     - mkl
     - liblapack {{ liblapack }}
     - pre-commit
+    
+    run_exports:
+      strong:
+       - boost {{ boost }}
+       - nexus
+       - numpy
+       - poco
+       - python {{ python }}
+       - librdkafka
+       - h5py
+       - mkl
+       - jsoncpp
+       - gsl
 
   run:
     - _openmp_mutex {{ _openmp_mutex }} [linux64]
-    - boost {{ boost }}
-    - h5py
-    - librdkafka
-    - nexus
-    - numpy
-    - poco
-    - python {{ python }}
     - python-dateutil
     - pyyaml
     - scipy
     - six
     - tbb
-    - gsl
-    - jsoncpp
     - muparser
-    - mkl
     - blis
 
 build:


### PR DESCRIPTION
Using conda-build 3 feature for strong runtime exports.

Avoid duplicating (and potential errors) from double listing build/run components.

A further improvement would be to start moving towards separate `host`/`build` sections.