### PR TITLE
Decrease scheduled task frequency

### DIFF
--- a/.azure-pipelines/cron.yml
+++ b/.azure-pipelines/cron.yml
@@ -1,6 +1,7 @@
 schedules:
-- cron: "0 4 * * *"
-  displayName: Daily morning build
+# Run at 4am on sundays
+- cron: "0 4 * * 0"
+  displayName: Weekly morning build
   branches:
     include:
     - main


### PR DESCRIPTION
This is a useful task to have. A number of times it's flagged up where incompatibilities have occurred, which is really important while we maintain our own recipe without looking after the mantid source day to day. Otherwise hunting down problems could take a significant amount of time and be costly.

Running this daily is however not efficient. Lets save on time, energy and CO2.